### PR TITLE
Fix imports for compiled Fortran modules

### DIFF
--- a/README
+++ b/README
@@ -67,24 +67,6 @@ I had to hack the scrip makefile for the fortran90 netcdf stuff. The
 anaconda netcdf-fortran reports:
     nf-config not yet implemented for cmake builds
 
-A note on the .so files from fortran: They might now end up with names like:
-
-    scrip.cpython-35m-x86_64-linux-gnu.so
-
-It's OK - they'll load as long as they are in your PYTHONPATH. You might
-also need libgu.so to be in your LD_LIBRARY_PATH. I'm getting inconsistent
-results with where the .so files need to be. Best results for me are if I go
-to the site-packages directory where pyroms got installed and copy all the
-.so files:
-
-    cp pyroms/*.so .
-    cp pyroms_toolbox/*.so .
-    cp bathy_smoother/*.so .
-
-Make sure this site-packages directory is in your PYTHONPATH. As for
-libgu.so, it went into $DESTDIR/lib, for me $HOME/python/lib - that's
-what needs to be in the LD_LIBRARY_PATH.
-
 Also, f2py may or may not be called f2py3, depending. It's listed explicitly
 in the scrip makefile and under pyroms_toolbox/pyroms_toolbox/src/makefile.
 

--- a/examples/Arctic2/remap.py
+++ b/examples/Arctic2/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     ystart=240
 
     # get time

--- a/examples/Arctic2/remap_bdry.py
+++ b/examples/Arctic2/remap_bdry.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bdry(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     ystart=240
 
     # get time
@@ -47,7 +47,7 @@ def remap_bdry(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, 
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_64BIT')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
 
     #get missing value

--- a/examples/Arctic2/remap_bdry_uv.py
+++ b/examples/Arctic2/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -166,7 +166,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     ncv.variables['vbar_west'].units = 'meter second-1'
     ncv.variables['vbar_west'].field = 'vbar_east, scalar, series'
 
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -266,7 +266,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     idxv_east = np.where(dst_grd.hgrid.mask_v[:,-1] == 0)
     idxu_west = np.where(dst_grd.hgrid.mask_u[:,0] == 0)
     idxv_west = np.where(dst_grd.hgrid.mask_v[:,0] == 0)
-    for n in range(dst_grd.vgrid.N): 
+    for n in range(dst_grd.vgrid.N):
         dst_u_north[n, idxu_north[0]] = spval
         dst_v_north[n, idxv_north[0]] = spval
         dst_u_south[n, idxu_south[0]] = spval
@@ -308,16 +308,16 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     for j in range(dst_v_east.shape[1]):
         dst_vbar_east[j] = (dst_v_east[:,j] * np.diff(z_v_east[:,j])).sum() / -z_v_east[0,j]
         dst_vbar_west[j] = (dst_v_west[:,j] * np.diff(z_v_west[:,j])).sum() / -z_v_west[0,j]
-        
+
     #mask
-    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)   
-    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)   
-    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)   
-    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)   
-    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)   
-    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)   
-    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)   
-    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)   
+    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)
+    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)
+    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)
+    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)
+    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)
+    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)
+    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)
+    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)
 
     # write data in destination file
     print('write data in destination file')

--- a/examples/Arctic2/remap_clm.py
+++ b/examples/Arctic2/remap_clm.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_clm(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     ystart=240
 
     # get time

--- a/examples/Arctic2/remap_clm_uv.py
+++ b/examples/Arctic2/remap_clm_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -112,7 +112,7 @@ def remap_clm_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
     ncv.variables['vbar'].time = 'ocean_time'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -181,7 +181,7 @@ def remap_clm_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/Arctic2/remap_uv.py
+++ b/examples/Arctic2/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -100,7 +100,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     ncv.variables['vbar'].long_name = '2D v-momentum component'
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -169,7 +169,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/Arctic_GLORYS/remap.py
+++ b/examples/Arctic_GLORYS/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     ystart=690
 
     # get time

--- a/examples/Arctic_GLORYS/remap_bdry.py
+++ b/examples/Arctic_GLORYS/remap_bdry.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bdry(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     ystart=690
 
     # get time

--- a/examples/Arctic_GLORYS/remap_bdry_uv.py
+++ b/examples/Arctic_GLORYS/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -174,7 +174,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     ncv.variables['vbar_west'].units = 'meter second-1'
     ncv.variables['vbar_west'].field = 'vbar_east, scalar, series'
 
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -275,7 +275,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     idxv_east = np.where(dst_grd.hgrid.mask_v[:,-1] == 0)
     idxu_west = np.where(dst_grd.hgrid.mask_u[:,0] == 0)
     idxv_west = np.where(dst_grd.hgrid.mask_v[:,0] == 0)
-    for n in range(dst_grd.vgrid.N): 
+    for n in range(dst_grd.vgrid.N):
         dst_u_north[n, idxu_north[0]] = spval
         dst_v_north[n, idxv_north[0]] = spval
         dst_u_south[n, idxu_south[0]] = spval
@@ -317,16 +317,16 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     for j in range(dst_v_east.shape[1]):
         dst_vbar_east[j] = (dst_v_east[:,j] * np.diff(z_v_east[:,j])).sum() / -z_v_east[0,j]
         dst_vbar_west[j] = (dst_v_west[:,j] * np.diff(z_v_west[:,j])).sum() / -z_v_west[0,j]
-        
+
     #mask
-    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)   
-    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)   
-    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)   
-    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)   
-    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)   
-    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)   
-    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)   
-    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)   
+    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)
+    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)
+    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)
+    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)
+    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)
+    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)
+    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)
+    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)
 
     # write data in destination file
     print('write data in destination file')

--- a/examples/Arctic_GLORYS/remap_uv.py
+++ b/examples/Arctic_GLORYS/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -109,7 +109,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     ncv.variables['vbar'].long_name = '2D v-momentum component'
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -179,7 +179,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/Arctic_HYCOM/remap.py
+++ b/examples/Arctic_HYCOM/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # get time
     nctime.long_name = 'time'
     nctime.units = 'days since 1900-01-01 00:00:00'
@@ -33,7 +33,7 @@ def remap(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_d
 #    time = date2num(time)
 #    time = time - ref
 #    time = time + 2.5 # 5-day average
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname][0]
     time = cdf.variables['ocean_time'][0]
 

--- a/examples/Arctic_HYCOM/remap_bdry.py
+++ b/examples/Arctic_HYCOM/remap_bdry.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -19,7 +19,7 @@ class nctime(object):
 def remap_bdry(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=2, dst_dir='./'):
 
     print(src_file)
-    
+
     # get time
     nctime.long_name = 'time'
     nctime.units = 'days since 1900-01-01 00:00:00'
@@ -36,7 +36,7 @@ def remap_bdry(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=2, 
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_64BIT')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
     time = cdf.variables['ocean_time'][0]
     print(time)

--- a/examples/Arctic_HYCOM/remap_bdry_uv.py
+++ b/examples/Arctic_HYCOM/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -158,7 +158,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=2, dst_dir='.
     ncv.variables['vbar_west'].units = 'meter second-1'
     ncv.variables['vbar_west'].field = 'vbar_east, scalar, series'
 
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -269,7 +269,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=2, dst_dir='.
     idxv_east = np.where(dst_grd.hgrid.mask_v[:,-1] == 0)
     idxu_west = np.where(dst_grd.hgrid.mask_u[:,0] == 0)
     idxv_west = np.where(dst_grd.hgrid.mask_v[:,0] == 0)
-    for n in range(dst_grd.vgrid.N): 
+    for n in range(dst_grd.vgrid.N):
         dst_u_north[n, idxu_north[0]] = spval
         dst_v_north[n, idxv_north[0]] = spval
         dst_u_south[n, idxu_south[0]] = spval
@@ -313,16 +313,16 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=2, dst_dir='.
     for j in range(dst_v_east.shape[1]):
         dst_vbar_east[j] = (dst_v_east[:,j] * np.diff(z_v_east[:,j])).sum() / -z_v_east[0,j]
         dst_vbar_west[j] = (dst_v_west[:,j] * np.diff(z_v_west[:,j])).sum() / -z_v_west[0,j]
-        
+
     #mask
-    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)   
-    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)   
-    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)   
-    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)   
-    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)   
-    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)   
-    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)   
-    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)   
+    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)
+    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)
+    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)
+    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)
+    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)
+    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)
+    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)
+    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)
 
     # write data in destination file
     print('write data in destination file')

--- a/examples/Arctic_HYCOM/remap_clm.py
+++ b/examples/Arctic_HYCOM/remap_clm.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_clm(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # get time
     nctime.long_name = 'time'
     nctime.units = 'days since 1900-01-01 00:00:00'
@@ -33,7 +33,7 @@ def remap_clm(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, d
 #    time = date2num(time)
 #    time = time - ref
 #    time = time + 2.5 # 5-day average
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname][0]
     time = cdf.variables['ocean_time'][0]
 

--- a/examples/Arctic_HYCOM/remap_clm_uv.py
+++ b/examples/Arctic_HYCOM/remap_clm_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -32,7 +32,7 @@ def remap_clm_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./
 #    time = date2num(time)
 #    time = time - ref
 #    time = time + 2.5 # 5-day average
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_varu = cdf.variables['u'][0]
     src_varv = cdf.variables['v'][0]
     time = cdf.variables['ocean_time'][0]
@@ -103,7 +103,7 @@ def remap_clm_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
     ncv.variables['vbar'].time = 'ocean_time'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -175,7 +175,7 @@ def remap_clm_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/Arctic_HYCOM/remap_uv.py
+++ b/examples/Arctic_HYCOM/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -32,7 +32,7 @@ def remap_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
 #    time = date2num(time)
 #    time = time - ref
 #    time = time + 2.5 # 5-day average
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_varu = cdf.variables['u'][0]
     src_varv = cdf.variables['v'][0]
     time = cdf.variables['ocean_time'][0]
@@ -99,7 +99,7 @@ def remap_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
     ncv.variables['vbar'].long_name = '2D v-momentum component'
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -171,7 +171,7 @@ def remap_uv(src_file, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/Arctic_SODA3.3.1/remap.py
+++ b/examples/Arctic_SODA3.3.1/remap.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Arctic_SODA3.3.1/remap_bdry.py
+++ b/examples/Arctic_SODA3.3.1/remap_bdry.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Arctic_SODA3.3.1/remap_bdry_uv.py
+++ b/examples/Arctic_SODA3.3.1/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Arctic_SODA3.3.1/remap_uv.py
+++ b/examples/Arctic_SODA3.3.1/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/BC_from_sta/station_bound.py
+++ b/examples/BC_from_sta/station_bound.py
@@ -11,7 +11,7 @@ except:
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 import matplotlib.pyplot as plt
 

--- a/examples/CCS1_SODA3.3.1/Boundary/remap_bdry.py
+++ b/examples/CCS1_SODA3.3.1/Boundary/remap_bdry.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bdry(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # CCS grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -87,7 +87,7 @@ def remap_bdry(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth
         field_west = 'zeta_west, scalar, series'
         units = 'meter'
     elif src_varname == 'temp':
-        src_var = src_var 
+        src_var = src_var
         Bpos = 't'
         Cpos = 'rho'
         z = src_grd.z_t

--- a/examples/CCS1_SODA3.3.1/Boundary/remap_bdry_uv.py
+++ b/examples/CCS1_SODA3.3.1/Boundary/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/CCS1_SODA3.3.1/Clim/remap.py
+++ b/examples/CCS1_SODA3.3.1/Clim/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # CCS grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -43,12 +43,12 @@ def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, k
         print('error : multiple frames in input file') ; exit()
     else:
         time = tmp[0]
-    
+
     # we need to correct the time axis
     ref_soda = dt.datetime(1980,1,1,0,0)
     ref_roms = dt.datetime(1900,1,1,0,0)
     ndays = (ref_soda - ref_roms).days
-    time = time + ndays 
+    time = time + ndays
 
     #get missing value
     spval = src_var.missing_value
@@ -75,7 +75,7 @@ def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, k
         units = 'meter'
         field = 'free-surface, scalar, series'
     elif src_varname == 'temp':
-        src_var = src_var 
+        src_var = src_var
         Bpos = 't'
         Cpos = 'rho'
         z = src_grd.z_t

--- a/examples/CCS1_SODA3.3.1/Clim/remap_uv.py
+++ b/examples/CCS1_SODA3.3.1/Clim/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -52,12 +52,12 @@ def remap_uv(src_fileuv, src_grd, dst_grd, dst_fileu, dst_filev, dmax=0, cdepth=
         print('error : multiple frames in input file') ; exit()
     else:
         time = tmp[0]
-    
+
     # we need to correct the time axis
     ref_soda = dt.datetime(1980,1,1,0,0)
     ref_roms = dt.datetime(1900,1,1,0,0)
     ndays = (ref_soda - ref_roms).days
-    time = time + ndays 
+    time = time + ndays
 
     #get missing value
     spval = src_varu.missing_value

--- a/examples/CCS1_SODA3.3.1/Initial/remap.py
+++ b/examples/CCS1_SODA3.3.1/Initial/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # CCS grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -43,12 +43,12 @@ def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, k
         print('error : multiple frames in input file') ; exit()
     else:
         time = tmp[0]
-    
+
     # we need to correct the time axis
     ref_soda = dt.datetime(1980,1,1,0,0)
     ref_roms = dt.datetime(1900,1,1,0,0)
     ndays = (ref_soda - ref_roms).days
-    time = time + ndays 
+    time = time + ndays
 
     #get missing value
     spval = src_var.missing_value
@@ -75,7 +75,7 @@ def remap(src_varname, src_file, src_grd, dst_grd, dst_file, dmax=0, cdepth=0, k
         units = 'meter'
         field = 'free-surface, scalar, series'
     elif src_varname == 'temp':
-        src_var = src_var 
+        src_var = src_var
         Bpos = 't'
         Cpos = 'rho'
         z = src_grd.z_t

--- a/examples/CCS1_SODA3.3.1/Initial/remap_uv.py
+++ b/examples/CCS1_SODA3.3.1/Initial/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -52,12 +52,12 @@ def remap_uv(src_fileuv, src_grd, dst_grd, dst_fileu, dst_filev, dmax=0, cdepth=
         print('error : multiple frames in input file') ; exit()
     else:
         time = tmp[0]
-    
+
     # we need to correct the time axis
     ref_soda = dt.datetime(1980,1,1,0,0)
     ref_roms = dt.datetime(1900,1,1,0,0)
     ndays = (ref_soda - ref_roms).days
-    time = time + ndays 
+    time = time + ndays
 
     #get missing value
     spval = src_varu.missing_value

--- a/examples/Palau_HYCOM/remap.py
+++ b/examples/Palau_HYCOM/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # get time
     nctime.long_name = 'time'
     nctime.units = 'days since 1900-01-01 00:00:00'
@@ -33,7 +33,7 @@ def remap(src_file, src_varname, src_grd, dst_grd, dxy=20, cdepth=0, kk=0, dst_d
 #    time = date2num(time)
 #    time = time - ref
 #    time = time + 2.5 # 5-day average
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname][0]
     time = cdf.variables['ocean_time'][0]
 

--- a/examples/Palau_HYCOM/remap_bdry.py
+++ b/examples/Palau_HYCOM/remap_bdry.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Palau_HYCOM/remap_bdry_uv.py
+++ b/examples/Palau_HYCOM/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Palau_HYCOM/remap_clm.py
+++ b/examples/Palau_HYCOM/remap_clm.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Palau_HYCOM/remap_clm_uv.py
+++ b/examples/Palau_HYCOM/remap_clm_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Palau_HYCOM/remap_uv.py
+++ b/examples/Palau_HYCOM/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/Yellow_Sea/Inputs/Boundary/remap_bdry.py
+++ b/examples/Yellow_Sea/Inputs/Boundary/remap_bdry.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bdry(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # YELLOW grid sub-sample
     xrange=(225, 275); yrange=(190, 240)
 
@@ -48,7 +48,7 @@ def remap_bdry(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, 
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_CLASSIC')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
 
     #get missing value

--- a/examples/Yellow_Sea/Inputs/Boundary/remap_bdry_uv.py
+++ b/examples/Yellow_Sea/Inputs/Boundary/remap_bdry_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -164,7 +164,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     ncv.variables['vbar_west'].units = 'meter second-1'
     ncv.variables['vbar_west'].field = 'vbar_east, scalar, series'
 
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -265,7 +265,7 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     idxv_east = np.where(dst_grd.hgrid.mask_v[:,-1] == 0)
     idxu_west = np.where(dst_grd.hgrid.mask_u[:,0] == 0)
     idxv_west = np.where(dst_grd.hgrid.mask_v[:,0] == 0)
-    for n in range(dst_grd.vgrid.N): 
+    for n in range(dst_grd.vgrid.N):
         dst_u_north[n, idxu_north[0]] = spval
         dst_v_north[n, idxv_north[0]] = spval
         dst_u_south[n, idxu_south[0]] = spval
@@ -307,16 +307,16 @@ def remap_bdry_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='.
     for j in range(dst_v_east.shape[1]):
         dst_vbar_east[j] = (dst_v_east[:,j] * np.diff(z_v_east[:,j])).sum() / -z_v_east[0,j]
         dst_vbar_west[j] = (dst_v_west[:,j] * np.diff(z_v_west[:,j])).sum() / -z_v_west[0,j]
-        
+
     #mask
-    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)   
-    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)   
-    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)   
-    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)   
-    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)   
-    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)   
-    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)   
-    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)   
+    dst_ubar_north = np.ma.masked_where(dst_grd.hgrid.mask_u[-1,:] == 0, dst_ubar_north)
+    dst_ubar_south = np.ma.masked_where(dst_grd.hgrid.mask_u[0,:] == 0, dst_ubar_south)
+    dst_ubar_east = np.ma.masked_where(dst_grd.hgrid.mask_u[:,-1] == 0, dst_ubar_east)
+    dst_ubar_west = np.ma.masked_where(dst_grd.hgrid.mask_u[:,0] == 0, dst_ubar_west)
+    dst_vbar_north = np.ma.masked_where(dst_grd.hgrid.mask_v[-1,:] == 0, dst_vbar_north)
+    dst_vbar_south = np.ma.masked_where(dst_grd.hgrid.mask_v[0,:] == 0, dst_vbar_south)
+    dst_vbar_east = np.ma.masked_where(dst_grd.hgrid.mask_v[:,-1] == 0, dst_vbar_east)
+    dst_vbar_west = np.ma.masked_where(dst_grd.hgrid.mask_v[:,0] == 0, dst_vbar_west)
 
     # write data in destination file
     print('write data in destination file')

--- a/examples/Yellow_Sea/Inputs/Initial/remap.py
+++ b/examples/Yellow_Sea/Inputs/Initial/remap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap(src_file, src_varname, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # YELLOW grid sub-sample
     xrange=(225, 275); yrange=(190, 240)
 

--- a/examples/Yellow_Sea/Inputs/Initial/remap_uv.py
+++ b/examples/Yellow_Sea/Inputs/Initial/remap_uv.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
@@ -100,7 +100,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     ncv.variables['vbar'].long_name = '2D v-momentum component'
     ncv.variables['vbar'].units = 'meter second-1'
     ncv.variables['vbar'].field = 'vbar-velocity,, scalar, series'
- 
+
 
     # remaping
     print('remapping and rotating u and v from', src_grd.name, \
@@ -170,7 +170,7 @@ def remap_uv(src_file, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     for i in range(dst_vbar.shape[1]):
         for j in range(dst_vbar.shape[0]):
             dst_vbar[j,i] = (dst_v[:,j,i] * np.diff(z_v[:,j,i])).sum() / -z_v[0,j,i]
-        
+
     # spval
     dst_ubar[idxu[0], idxu[1]] = spval
     dst_vbar[idxv[0], idxv[1]] = spval

--- a/examples/cobalt-preproc/Arctic/remap_bio.py
+++ b/examples/cobalt-preproc/Arctic/remap_bio.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Arctic/remap_bio_glodap.py
+++ b/examples/cobalt-preproc/Arctic/remap_bio_glodap.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Arctic/remap_bio_woa.py
+++ b/examples/cobalt-preproc/Arctic/remap_bio_woa.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio.py
+++ b/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio_glodap.py
+++ b/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio_glodap.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio_woa.py
+++ b/examples/cobalt-preproc/Boundary_bio/remap_bdry_bio_woa.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Clim_bio/remap_bio.py
+++ b/examples/cobalt-preproc/Clim_bio/remap_bio.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bio(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # NWGOA3 grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -44,7 +44,7 @@ def remap_bio(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_64BIT')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
 
     # correct time to some classic value

--- a/examples/cobalt-preproc/Clim_bio/remap_bio_glodap.py
+++ b/examples/cobalt-preproc/Clim_bio/remap_bio_glodap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # NWGOA3 grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -44,7 +44,7 @@ def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir=
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_64BIT')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
 
     # correct time to some classic value
@@ -66,9 +66,9 @@ def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir=
         src_var = src_var[0,yrange[0]:yrange[1]+1, xrange[0]:xrange[1]+1]
 
     if tracer == 'alk':
-       unit_conversion = 1. / 1e6 
+       unit_conversion = 1. / 1e6
     elif tracer == 'dic':
-       unit_conversion = 1. / 1e6 
+       unit_conversion = 1. / 1e6
 
     src_var = src_var * unit_conversion
 

--- a/examples/cobalt-preproc/Clim_bio/remap_bio_woa.py
+++ b/examples/cobalt-preproc/Clim_bio/remap_bio_woa.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Initial_bio/remap_bio.py
+++ b/examples/cobalt-preproc/Initial_bio/remap_bio.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/cobalt-preproc/Initial_bio/remap_bio_glodap.py
+++ b/examples/cobalt-preproc/Initial_bio/remap_bio_glodap.py
@@ -11,13 +11,13 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass
 
 def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir='./'):
-    
+
     # NWGOA3 grid sub-sample
     xrange=src_grd.xrange; yrange=src_grd.yrange
 
@@ -44,7 +44,7 @@ def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir=
     nc = netCDF.Dataset(dst_file, 'a', format='NETCDF3_64BIT')
 
     #load var
-    cdf = netCDF.Dataset(src_file) 
+    cdf = netCDF.Dataset(src_file)
     src_var = cdf.variables[src_varname]
 
     tmp = cdf.variables['time'][nframe]
@@ -73,9 +73,9 @@ def remap_bio_glodap(argdict, src_grd, dst_grd, dmax=0, cdepth=0, kk=0, dst_dir=
         src_var = src_var[0,yrange[0]:yrange[1]+1, xrange[0]:xrange[1]+1]
 
     if tracer == 'alk':
-       unit_conversion = 1. / 1e6 
+       unit_conversion = 1. / 1e6
     elif tracer == 'dic':
-       unit_conversion = 1. / 1e6 
+       unit_conversion = 1. / 1e6
 
     src_var = src_var * unit_conversion
 

--- a/examples/cobalt-preproc/Initial_bio/remap_bio_woa.py
+++ b/examples/cobalt-preproc/Initial_bio/remap_bio_woa.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/examples/make_tide/CGrid_TPXO8/flood.py
+++ b/examples/make_tide/CGrid_TPXO8/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 
@@ -16,7 +16,7 @@ def flood(varz, Cgrd, Cpos='t', irange=None, jrange=None, \
       - irange                       specify grid sub-sample for i direction
       - jrange                       specify grid sub-sample for j direction
       - spval=1e35                   define spval value
-      - dmax=0                       if dmax>0, maximum horizontal 
+      - dmax=0                       if dmax>0, maximum horizontal
                                      flooding distance
       - cdepth=0                     critical depth for flooding
                                      if depth<cdepth => no flooding

--- a/examples/make_tide/CGrid_TPXO8/remap.py
+++ b/examples/make_tide/CGrid_TPXO8/remap.py
@@ -11,7 +11,7 @@ from matplotlib.dates import date2num, num2date
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 class nctime(object):
     pass

--- a/pyroms/pyroms/remapping/__init__.py
+++ b/pyroms/pyroms/remapping/__init__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-''' 
+'''
 A set of tools for remapping
 '''
 
@@ -9,7 +9,7 @@ from .test_remap_weights import test_remap_weights
 from .remap import remap
 from .remap2 import remap2
 try:
-    import scrip
+    from pyroms import scrip
 except:
     print('scrip.so not found. Remapping function will not be available')
 from .roms2z import roms2z

--- a/pyroms/pyroms/remapping/flood.py
+++ b/pyroms/pyroms/remapping/flood.py
@@ -1,9 +1,10 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
 
 import pyroms
+from pyroms import _remapping
+
 
 def flood(varz, grdz, Cpos='rho', irange=None, jrange=None, \
           spval=1e37, dmax=0, cdepth=0, kk=0):

--- a/pyroms/pyroms/remapping/flood2d.py
+++ b/pyroms/pyroms/remapping/flood2d.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 def flood2d(varz, grdz, Cpos='rho', irange=None, jrange=None, \
           spval=1e37, dmax=0, cdepth=0, kk=0):

--- a/pyroms/pyroms/remapping/roms2z.py
+++ b/pyroms/pyroms/remapping/roms2z.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _interp
+from pyroms import _interp
 
 def roms2z(var, grd, grdz, Cpos='rho', irange=None, jrange=None, \
            spval=1e37, mode='linear'):

--- a/pyroms/pyroms/remapping/sta2z.py
+++ b/pyroms/pyroms/remapping/sta2z.py
@@ -1,8 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _interp
-import pdb
+from pyroms import _interp
 
 def sta2z(var, grd, grdz, Cpos='rho', srange=None, \
            spval=1e37, mode='linear'):
@@ -77,5 +76,5 @@ def sta2z(var, grd, grdz, Cpos='rho', srange=None, \
     idx = np.where(abs((varz-spval)/spval)<=1e-5)
     varz[idx] = spval
     #varz = np.ma.masked_values(varz, spval, rtol=1e-5)
-    
+
     return varz

--- a/pyroms/pyroms/remapping/z2roms.py
+++ b/pyroms/pyroms/remapping/z2roms.py
@@ -1,8 +1,8 @@
 # encoding: utf-8
 
 import numpy as np
-import _interp
-import _remapping
+from pyroms import _interp
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms/pyroms/tools.py
+++ b/pyroms/pyroms/tools.py
@@ -1,8 +1,9 @@
 # encoding: utf-8
 
 import numpy as np
-import _iso
-import _obs_interp
+
+from . import _iso
+from . import _obs_interp
 
 import pyroms
 

--- a/pyroms/pyroms/utility.py
+++ b/pyroms/pyroms/utility.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from scipy import interpolate
 
 import pyroms
-import _interp
+from pyroms import _interp
 
 
 def get_lonlat(iindex, jindex, grd, Cpos='rho'):

--- a/pyroms_toolbox/pyroms_toolbox/BGrid_GFDL/flood.py
+++ b/pyroms_toolbox/pyroms_toolbox/BGrid_GFDL/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/BGrid_POP/flood.py
+++ b/pyroms_toolbox/pyroms_toolbox/BGrid_POP/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/BGrid_SODA/flood.py
+++ b/pyroms_toolbox/pyroms_toolbox/BGrid_SODA/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/CGrid_GLORYS/flood.py
+++ b/pyroms_toolbox/pyroms_toolbox/CGrid_GLORYS/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood.py
+++ b/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping
+from pyroms import _remapping
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood_fast.py
+++ b/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood_fast.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping_fast
+from pyroms import _remapping_fast
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood_fast_weighted.py
+++ b/pyroms_toolbox/pyroms_toolbox/Grid_HYCOM/flood_fast_weighted.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import numpy as np
-import _remapping_fast_weighted
+from pyroms import _remapping_fast_weighted
 
 import pyroms
 

--- a/pyroms_toolbox/pyroms_toolbox/remapping.py
+++ b/pyroms_toolbox/pyroms_toolbox/remapping.py
@@ -11,7 +11,7 @@ except:
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 import matplotlib.pyplot as plt
 

--- a/pyroms_toolbox/pyroms_toolbox/remapping_bound.py
+++ b/pyroms_toolbox/pyroms_toolbox/remapping_bound.py
@@ -11,7 +11,7 @@ except:
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 import matplotlib.pyplot as plt
 

--- a/pyroms_toolbox/pyroms_toolbox/remapping_bound_sig.py
+++ b/pyroms_toolbox/pyroms_toolbox/remapping_bound_sig.py
@@ -11,7 +11,7 @@ except:
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 import matplotlib.pyplot as plt
 

--- a/pyroms_toolbox/pyroms_toolbox/remapping_tensor.py
+++ b/pyroms_toolbox/pyroms_toolbox/remapping_tensor.py
@@ -10,7 +10,7 @@ except:
 
 import pyroms
 import pyroms_toolbox
-import _remapping
+from pyroms import _remapping
 
 import matplotlib.pyplot as plt
 
@@ -56,12 +56,12 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
     # get wts_file
     if type(wts_files).__name__ == 'str':
         wts_files = sorted(glob.glob(wts_files))
- 
+
     # loop over the srcfile
     for nf in range(nfile):
         print('Working with file', srcfile[nf], '...')
 
-        # get time 
+        # get time
         ocean_time = pyroms.utility.get_nc_var('ocean_time', srcfile[nf])
         ntime = len(ocean_time[:])
 
@@ -89,7 +89,7 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
                 print(' ')
                 print('remapping', varname[nv], 'from', srcgrd.name, \
                       'to', dstgrd.name)
-                print('time =', ocean_time[nt])   
+                print('time =', ocean_time[nt])
 
                 # get source data
                 src_var = pyroms.utility.get_nc_var(varname[nv], srcfile[nf])
@@ -98,7 +98,7 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
                 try:
                     spval = src_var._FillValue
                 except:
-                    raise Warning('Did not find a _FillValue attribute.') 
+                    raise Warning('Did not find a _FillValue attribute.')
 
                 # irange
                 if irange is None:
@@ -151,7 +151,7 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
 
             # rotate the velocity field if requested
 #            print datetime.datetime.now()
-            print(' ') 
+            print(' ')
             print('remapping and rotating sigma from', srcgrd.name, \
                   'to', dstgrd.name)
 
@@ -161,7 +161,7 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
             try:
                 spval = src_11._FillValue
             except:
-                raise Warning('Did not find a _FillValue attribute.') 
+                raise Warning('Did not find a _FillValue attribute.')
 
             src_11 = src_11[nt,jjrange[0]:jjrange[1],iirange[0]:iirange[1]]
 
@@ -233,7 +233,7 @@ def remapping_tensor(varname, srcfile, wts_files, srcgrd, dstgrd, \
 
         nctidx = nctidx + 1
         nc.sync()
- 
+
     # close destination file
     nc.close()
 


### PR DESCRIPTION
Hi, many imports in pyroms source code suppose compiled fortran modules are in PYTHONPATH.
Therefore, they can't be directly loaded by default:
```python
>>> import pyroms
scrip.so not found. Remapping function will not be available
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/honnorat/usr/conda/envs/pyroms/lib/python3.7/site-packages/pyroms/__init__.py", line 20, in <module>
    from . import remapping
  File "/home/honnorat/usr/conda/envs/pyroms/lib/python3.7/site-packages/pyroms/remapping/__init__.py", line 18, in <module>
    from .flood import flood
  File "/home/honnorat/usr/conda/envs/pyroms/lib/python3.7/site-packages/pyroms/remapping/flood.py", line 4, in <module>
    import _remapping
ModuleNotFoundError: No module named '_remapping'
```

This PR replace abolute imports with relative imports (`from pyroms import _remapping`), which fixes the issue.