### PR TITLE
Bugfix iso.f

### DIFF
--- a/pyroms/pyroms/src/iso.f
+++ b/pyroms/pyroms/src/iso.f
@@ -98,7 +98,7 @@
 !f2py intent(hide) :: N
       integer i, j, k
       real*8 zk(N), fk(N)
-      real*8 wk(N), dfdz(N)
+      real*8 wk(N), dfdz
 
 !  Linear Interpolation.
       if (vinterp.eq.0) then


### PR DESCRIPTION
Fixed dimension of "dfdz" in subroutine "zslice" to avoid compile error.