### PR TITLE
Fix: ValueError: A distribution name is required.

### DIFF
--- a/bathy_smoother/setup.py
+++ b/bathy_smoother/setup.py
@@ -33,7 +33,7 @@ def configuration(parent_package='',top_path=None):
 
 if __name__ == '__main__':
     from numpy.distutils.core import setup
-    setup(name = '',
+    setup(name = 'bathy_smoother',
           version = '0.2.0',
           description = doclines[0],
           long_description = "\n".join(doclines[2:]),


### PR DESCRIPTION
## Description
- When installing pyroms/bathy_smoother, the installation fails because the distribution name does not exist
- The following command was reproduced with miniconda3 Docker and Python 3.8

```bash
$ pip install -e pyroms/bathy_smoother

Preparing metadata (setup.py): started
Preparing metadata (setup.py): finished with status 'error'
error: subprocess-exited-with-error

× python setup.py egg_info did not run successfully.
│ exit code: 1
╰─> [24 lines of output]
    Traceback (most recent call last):
      File "<string>", line 2, in <module>
      File "<pip-setuptools-caller>", line 34, in <module>
      File "/home/user/pyroms/bathy_smoother/setup.py", line 36, in <module>
        setup(name = '',
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/numpy/distutils/core.py", line 126, in setup
        dist = setup(**new_attr)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/numpy/distutils/core.py", line 169, in setup
        return old_setup(**new_attr)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/__init__.py", line 103, in setup
        return distutils.core.setup(**attrs)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 147, in setup
        _setup_distribution = dist = klass(attrs)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/numpy/distutils/numpy_distribution.py", line 14, in __init__
        Distribution.__init__(self, attrs)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/dist.py", line 294, in __init__
        self.patch_missing_pkg_info(attrs)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/dist.py", line 281, in patch_missing_pkg_info
        dist = metadata.distribution(name)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 805, in distribution
        return Distribution.from_name(distribution_name)
      File "/opt/conda/envs/myenv/lib/python3.8/site-packages/setuptools/_vendor/importlib_metadata/__init__.py", line 379, in from_name
        raise ValueError("A distribution name is required.")
    ValueError: A distribution name is required.
    [end of output]
```

## Changes
- Added name to bathy_smoother's setup
- Note that [pyroms](https://github.com/ESMG/pyroms/blob/5ea501ef904b01036dd2a0909b7bdc61a56e7eff/pyroms/setup.py#L94) and [pyroms_toolbox](https://github.com/ESMG/pyroms/blob/5ea501ef904b01036dd2a0909b7bdc61a56e7eff/pyroms_toolbox/setup.py#L46) already have names set, so no error occurred.